### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -4,6 +4,9 @@ on:
     types: [created]
     
   workflow_dispatch:
+
+permissions:
+  contents: read
   
 jobs:
   publish:


### PR DESCRIPTION
Potential fix for [https://github.com/filip26/titanium-rdf-n-quads/security/code-scanning/1](https://github.com/filip26/titanium-rdf-n-quads/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/maven-publish.yml` at the workflow root (preferred here since there is one job), setting only the minimal scope needed. For this workflow, `actions/checkout` needs repository contents read access, so `contents: read` is the best minimal setting. No other workflow functionality in the shown snippet requires broader GitHub token permissions.

Concretely, insert:

- `permissions:`
- `  contents: read`

between the trigger section and `jobs:` (e.g., after `workflow_dispatch:`).  
No imports, methods, or dependencies are required—this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
